### PR TITLE
fix: prevent undefined URL construction when options.server is not provided

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -150,14 +150,19 @@ export async function whois(
 
   const selfRdap = thinResponse?.links?.find((link: any) => link.rel === "self");
 
-  const thickRdap = thinResponse.links
+  // Find the thick RDAP URL from the thin response's links
+  const thickRdapFromLinks = thinResponse?.links
     ?.find(
       (link: any) =>
         link.href !== selfRdap?.href &&
         link.rel === "related" &&
         link.type === "application/rdap+json"
     )
-    ?.href.replace("/domain/domain/", "/domain/") || `${options.server}/domain/${domain}`;
+    ?.href.replace("/domain/domain/", "/domain/");
+
+  // Only use options.server as fallback if it's actually defined
+  // This prevents constructing invalid URLs like "undefined/domain/example.com"
+  const thickRdap = thickRdapFromLinks || (options.server ? `${options.server}/domain/${domain}` : null);
 
   let thickResponse: any = null;
 


### PR DESCRIPTION
The thick RDAP URL fallback was using string interpolation with
options.server even when it was undefined, resulting in invalid URLs
like "undefined/domain/example.com".

This occurs for thick registries (like .uk, .nl, .org) where the registry
holds all domain data and doesn't provide a "related" link to a
registrar's RDAP server. In these cases, no thick lookup is needed.

Now only uses options.server as fallback if it's actually defined,
otherwise sets thickRdap to null which correctly skips the unnecessary
thick lookup for thick registries.

Fixes TypeError: Failed to parse URL from undefined/domain/...